### PR TITLE
optimize calls to number_of_columns() in SheetReader._iterate_columns()

### DIFF
--- a/pyexcel_io/database/querysets.py
+++ b/pyexcel_io/database/querysets.py
@@ -23,7 +23,7 @@ class QuerysetsReader(SheetReader):
         return chain([self.__column_names],
                      self.__query_sets)
 
-    def _iterate_columns(self, row):
+    def _iterate_columns(self, row, ncols):
         if self.__column_names is not None:
             if isinstance(row, list):
                 for element in row:

--- a/pyexcel_io/fileformat/_csv.py
+++ b/pyexcel_io/fileformat/_csv.py
@@ -91,7 +91,7 @@ class CSVSheetReader(SheetReader):
     def _iterate_rows(self):
         return csv.reader(self.get_file_handle(), **self._keywords)
 
-    def _iterate_columns(self, row):
+    def _iterate_columns(self, row, ncols):
         for element in row:
             if compact.PY2:
                 element = element.decode('utf-8')

--- a/pyexcel_io/sheet.py
+++ b/pyexcel_io/sheet.py
@@ -52,6 +52,7 @@ class SheetReader(object):
     def to_array(self):
         """2 dimentional representation of the content
         """
+        ncols = hasattr(self, 'number_of_columns') and self.number_of_columns()
         for row_index, row in enumerate(self._iterate_rows()):
             row_position = self._skip_row(
                 row_index, self._start_row, self._row_limit)
@@ -64,7 +65,7 @@ class SheetReader(object):
             tmp_row = []
 
             for column_index, cell_value in enumerate(
-                    self._iterate_columns(row)):
+                    self._iterate_columns(row, ncols)):
                 column_position = self._skip_column(
                     column_index, self._start_column, self._column_limit)
                 if column_position == constants.SKIP_DATA:
@@ -89,8 +90,8 @@ class SheetReader(object):
     def _iterate_rows(self):
         return irange(self.number_of_rows())
 
-    def _iterate_columns(self, row):
-        for column in irange(self.number_of_columns()):
+    def _iterate_columns(self, row, ncols):
+        for column in irange(ncols):
             yield self._cell_value(row, column)
 
     def _cell_value(self, row, column):


### PR DESCRIPTION
This can be costly for certain implementations e.g. pyexcel-xlsx (which internally uses openpyxl) where it is computed on-the-fly.

It isn't possible to make the fix in pyexcel-xlsx as there is the possibility of it changing due to modifications via the API. One does have to make the (rather reasonable) assumption that the number of columns doesn't change during execution of  `to_array`.