### PR TITLE
Change to allow to work with pyinstaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pyexcel*-info
 build
 dist
 tmp.db
+.idea/*

--- a/pyexcel_io/__init__.py
+++ b/pyexcel_io/__init__.py
@@ -19,21 +19,43 @@ from . import fileformat, database
 
 exports = fileformat.exports + database.exports
 
-from pkgutil import iter_modules
+import pkgutil
 
 black_list = [__name__, 'pyexcel_webio', 'pyexcel_text']
 
-for _, module_name, ispkg in iter_modules():
+# load modules to work based with and without pyinstaller
+# from: https://github.com/webcomics/dosage/blob/master/dosagelib/loader.py
+# see: https://github.com/pyinstaller/pyinstaller/issues/1905
+# load modules using iter_modules()
+# (should find all plug ins in normal build, but not pyinstaller)
+
+prefix = 'pyexcel_'
+
+module_names = [m[1] for m in pkgutil.iter_modules()
+                if m[2] and m[1].startswith(prefix)]
+
+# special handling for PyInstaller
+toc = set()
+for t in (i.toc for i in map(pkgutil.get_importer, __path__)
+          if hasattr(i, 'toc')):
+    toc |= t
+
+for elm in toc:
+    if elm.startswith(prefix) and '.' not in elm:
+        module_names.append(elm)
+
+# loop through modules and find our plug ins
+for module_name in module_names:
+
     if module_name in black_list:
         continue
 
-    if ispkg and module_name.startswith('pyexcel_'):
-        try:
-            plugin = __import__(module_name)
-            if hasattr(plugin, '__pyexcel_io_plugins__'):
-                for p in plugin.__pyexcel_io_plugins__:
-                    pre_register(p, module_name)
-        except ImportError:
-            continue
+    try:
+        plugin = __import__(module_name)
+        if hasattr(plugin, '__pyexcel_io_plugins__'):
+            for p in plugin.__pyexcel_io_plugins__:
+                pre_register(p, module_name)
+    except ImportError:
+        continue
 
 register_readers_and_writers(exports)


### PR DESCRIPTION
Pyinstaller does not support `pkg_utils.iter_modules()`.  Instead one needs to use `pkgutil.get_importer()` to see what is available. See https://github.com/pyinstaller/pyinstaller/issues/1905 for details.