### PR TITLE
🐛 fix loading CSV ‘books’ if the path contains ‘.’

### DIFF
--- a/pyexcel_io/readers/csvr.py
+++ b/pyexcel_io/readers/csvr.py
@@ -305,7 +305,7 @@ class CSVBookReader(BookReader):
         self.__line_terminator = self._keywords.get(
             constants.KEYWORD_LINE_TERMINATOR,
             self.__line_terminator)
-        names = self._file_name.split('.')
+        names = self._file_name.rsplit('.', 1)
         filepattern = "%s%s*%s*.%s" % (
             names[0],
             constants.DEFAULT_MULTI_CSV_SEPARATOR,


### PR DESCRIPTION
The CSV book reader erronously split the path by _all_ dots, instead
of just the last one. This is what os.path.splitext() is for, but
since it drops the leading dot, I kept the split() call to keep the
change minimal.

I tried to create a testcase for this, but it turned out to be harder than expected since I don't quite understand the internal design of _pyexcel_.