### PR TITLE
Replace deprecated BadZipfile with BadZipFile

### DIFF
--- a/pyexcel_io/database/common.py
+++ b/pyexcel_io/database/common.py
@@ -85,7 +85,6 @@ class DjangoModelImportAdapter(DjangoModelExportAdapter):
             self._column_names.output = self._column_name_mapping_dict.input
             self._column_name_mapping_dict.output = None
         elif isinstance(self._column_name_mapping_dict.input, dict):
-
             if self._column_names.input:
                 self._column_names.output = []
                 indices = []

--- a/pyexcel_io/readers/csvz.py
+++ b/pyexcel_io/readers/csvz.py
@@ -32,7 +32,7 @@ class FileReader(IReader):
             if file_type == constants.FILE_FORMAT_TSVZ:
                 self.keywords["dialect"] = constants.KEYWORD_TSV_DIALECT
 
-        except zipfile.BadZipfile:
+        except zipfile.BadZipFile:
             print("StringIO instance was passed by any chance?")
             raise
 

--- a/tests/test_csv_book.py
+++ b/tests/test_csv_book.py
@@ -150,7 +150,7 @@ def test_utf16_decoding():
 
 
 def test_utf16_encoding():
-    content = [[u"Äkkilähdöt", u"Matkakirjoituksia", u"Matkatoimistot"]]
+    content = [["Äkkilähdöt", "Matkakirjoituksia", "Matkatoimistot"]]
     test_file = "test-utf16-encoding.csv"
     writer = CSVFileWriter(
         test_file, None, encoding="utf-16", lineterminator="\n"
@@ -164,7 +164,7 @@ def test_utf16_encoding():
 
 
 def test_utf16_memory_decoding():
-    test_content = u"Äkkilähdöt,Matkakirjoituksia,Matkatoimistot"
+    test_content = "Äkkilähdöt,Matkakirjoituksia,Matkatoimistot"
     test_content = BytesIO(test_content.encode("utf-16"))
     reader = EncapsulatedSheetReader(
         CSVinMemoryReader(NamedContent("csv", test_content), encoding="utf-16")
@@ -176,7 +176,7 @@ def test_utf16_memory_decoding():
 
 
 def test_utf16_memory_encoding():
-    content = [[u"Äkkilähdöt", u"Matkakirjoituksia", u"Matkatoimistot"]]
+    content = [["Äkkilähdöt", "Matkakirjoituksia", "Matkatoimistot"]]
     io = StringIO()
     writer = CSVMemoryWriter(
         io,
@@ -187,4 +187,4 @@ def test_utf16_memory_encoding():
     )
     writer.write_array(content)
     actual = io.getvalue()
-    eq_(actual, u"Äkkilähdöt,Matkakirjoituksia,Matkatoimistot\n")
+    eq_(actual, "Äkkilähdöt,Matkakirjoituksia,Matkatoimistot\n")

--- a/tests/test_django_book.py
+++ b/tests/test_django_book.py
@@ -267,10 +267,10 @@ class TestMultipleModels:
     def setUp(self):
         self.content = OrderedDict()
         self.content.update(
-            {"Sheet1": [[u"X", u"Y", u"Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
+            {"Sheet1": [["X", "Y", "Z"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
         )
         self.content.update(
-            {"Sheet2": [[u"A", u"B", u"C"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
+            {"Sheet2": [["A", "B", "C"], [1, 4, 7], [2, 5, 8], [3, 6, 9]]}
         )
         self.result1 = [
             {"Y": 4, "X": 1, "Z": 7},

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,6 @@
 import os
 import types
-from zipfile import BadZipfile
+from zipfile import BadZipFile
 from unittest import TestCase
 
 import pyexcel_io.manager as manager
@@ -111,7 +111,7 @@ def test_load_unknown_data_from_memory():
     get_data(io, file_type="unknown")
 
 
-@raises(BadZipfile)
+@raises(BadZipFile)
 def test_load_csvz_data_from_memory():
     io = StringIO()
     get_data(io, file_type="csvz")

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -22,7 +22,7 @@ def test_issue_8():
 def test_issue_20():
     test_file = get_fixture("issue20.csv")
     data = get_data(test_file)
-    expected = [[u"to", u"infinity", u"and", u"beyond"]]
+    expected = [["to", "infinity", "and", "beyond"]]
     eq_(data["issue20.csv"], expected)
 
 
@@ -30,8 +30,8 @@ def test_issue_23():
     test_file = get_fixture("issue23.csv")
     data = get_data(test_file)
     expected = [
-        [8204235414504252, u"inf"],
-        [82042354145042521, u"-inf"],
+        [8204235414504252, "inf"],
+        [82042354145042521, "-inf"],
         [820423541450425216, 0],
         [820423541450425247, 1],
         [8204235414504252490, 1.1],
@@ -46,7 +46,7 @@ def test_issue_33_34():
     with open(test_file, "r+b") as f:
         memory_mapped_file = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
         data = get_data(memory_mapped_file, file_type="csv")
-        expected = [[u"to", u"infinity", u"and", u"beyond"]]
+        expected = [["to", "infinity", "and", "beyond"]]
         eq_(data["csv"], expected)
 
 
@@ -94,8 +94,8 @@ def check_mmap_encoding(encoding):
     import mmap
 
     content = [
-        [u"Äkkilähdöt", u"Matkakirjoituksia", u"Matkatoimistot"],
-        [u"Äkkilähdöt", u"Matkakirjoituksia", u"Matkatoimistot"],
+        ["Äkkilähdöt", "Matkakirjoituksia", "Matkatoimistot"],
+        ["Äkkilähdöt", "Matkakirjoituksia", "Matkatoimistot"],
     ]
     test_file = "test-%s-encoding-in-mmap-file.csv" % encoding
     save_data(test_file, content, encoding=encoding)
@@ -111,8 +111,8 @@ def check_mmap_encoding(encoding):
 def test_issue_35_encoding_for_file_content():
     encoding = "utf-16"
     content = [
-        [u"Äkkilähdöt", u"Matkakirjoituksia", u"Matkatoimistot"],
-        [u"Äkkilähdöt", u"Matkakirjoituksia", u"Matkatoimistot"],
+        ["Äkkilähdöt", "Matkakirjoituksia", "Matkatoimistot"],
+        ["Äkkilähdöt", "Matkakirjoituksia", "Matkatoimistot"],
     ]
     test_file = "test-%s-encoding-in-mmap-file.csv" % encoding
     save_data(test_file, content, encoding=encoding)

--- a/tests/test_new_csvz_book.py
+++ b/tests/test_new_csvz_book.py
@@ -14,7 +14,7 @@ from nose.tools import raises
 
 class TestCSVZ(TestCase):
     file_type = "csvz"
-    result = u"中,文,1,2,3"
+    result = "中,文,1,2,3"
 
     def writer_class(self):
         return Writer(self.file_type)
@@ -26,7 +26,7 @@ class TestCSVZ(TestCase):
         self.file = "csvz." + self.file_type
 
     def test_writing(self):
-        data = [[u"中", u"文", 1, 2, 3]]
+        data = [["中", "文", 1, 2, 3]]
         file_name = "pyexcel_sheet1." + self.file_type[0:3]
         zipbook = self.writer_class()
         zipbook.open(self.file)
@@ -40,7 +40,7 @@ class TestCSVZ(TestCase):
         zip.close()
 
     def test_reading(self):
-        data = [[u"中", u"文", 1, 2, 3]]
+        data = [["中", "文", 1, 2, 3]]
         zipbook = self.writer_class()
         zipbook.open(self.file)
         zipbook.write({None: data})
@@ -48,7 +48,7 @@ class TestCSVZ(TestCase):
         zipreader = self.reader_class()
         zipreader.open(self.file)
         data = zipreader.read_all()
-        self.assertEqual(list(data["pyexcel_sheet1"]), [[u"中", u"文", 1, 2, 3]])
+        self.assertEqual(list(data["pyexcel_sheet1"]), [["中", "文", 1, 2, 3]])
         zipreader.close()
 
     def test_reading_utf32(self):
@@ -58,7 +58,7 @@ class TestCSVZ(TestCase):
         zipreader = self.reader_class()
         zipreader.open(self.file)
         data = zipreader.read_all()
-        self.assertEqual(list(data["something"]), [[u"中", u"文", 1, 2, 3]])
+        self.assertEqual(list(data["something"]), [["中", "文", 1, 2, 3]])
         zipreader.close()
 
     def tearDown(self):
@@ -67,7 +67,7 @@ class TestCSVZ(TestCase):
 
 class TestTSVZ(TestCSVZ):
     file_type = "tsvz"
-    result = u"中\t文\t1\t2\t3"
+    result = "中\t文\t1\t2\t3"
 
 
 def test_reading_from_memory():


### PR DESCRIPTION
With your PR, here is a check list:

- [n/a] Has test cases written?
- [x] Has all code lines tested?
- [x] Has `make format` been run?
- [n/a] Please update CHANGELOG.yml(not CHANGELOG.rst)
- [n/a] Has fair amount of documentation if your change is complex
- [x] Agree on NEW BSD License for your contribution

`BadZipfile` (with a small `f`) has been deprecated since Python 3.2, use `BadZipFile` (big `F`) instead, added in 3.2.

* https://docs.python.org/3/library/zipfile.html#zipfile.BadZipfile
* https://github.com/python/cpython/issues/86437
